### PR TITLE
Feature: optional centering

### DIFF
--- a/src/lib/components/Timeline.svelte
+++ b/src/lib/components/Timeline.svelte
@@ -3,24 +3,32 @@
 	import type { TimelinePosition, TimelineConfig } from '../types';
 	interface Props {
 		position?: TimelinePosition;
+		center?: boolean;
 		style?: string;
 		children?: import('svelte').Snippet;
 	}
 
-	let { position = 'right', style = null, children }: Props = $props();
+	let { position = 'right', center = true, style = null, children }: Props = $props();
 
-	setContext<TimelineConfig>('TimelineConfig', { rootPosition: position });
+	setContext<TimelineConfig>('TimelineConfig', { rootPosition: position, center: center });
 </script>
 
-<ul class="timeline" {style}>
+<div class={`timeline center-${center}`} {style}>
 	{@render children?.()}
-</ul>
+</div>
 
 <style>
 	.timeline {
-		display: flex;
-		flex-direction: column;
+		display: grid;
+		grid-auto-flow: row dense;
 		padding: 6px 16px;
 		flex-grow: 1;
+	}
+
+	.center-true {
+		grid-template-columns: 1fr min-content 1fr;
+	}
+	.center-false {
+		grid-template-columns: auto min-content auto;
 	}
 </style>

--- a/src/lib/components/Timeline.svelte
+++ b/src/lib/components/Timeline.svelte
@@ -20,6 +20,7 @@
 <style>
 	.timeline {
 		display: grid;
+		grid-auto-rows: minmax(70px, auto);
 		grid-auto-flow: row dense;
 		padding: 6px 16px;
 		flex-grow: 1;

--- a/src/lib/components/TimelineContent.svelte
+++ b/src/lib/components/TimelineContent.svelte
@@ -21,15 +21,28 @@
 <style>
 	.timeline-content {
 		margin: 0;
-		flex: 1;
 		margin: 6px 16px;
+		width: fit-content;
+	}
+
+	.alternate:nth-child(odd of .timeline-content) {
+		grid-column-start: 1;
+		justify-self: end;
+		text-align: right;
+	}
+	.alternate:nth-child(even of .timeline-content) {
+		grid-column-start: 3;
+		justify-self: start;
 	}
 
 	.left {
+		grid-column-start: 1;
+		justify-self: end;
 		text-align: right;
 	}
 
 	.right {
+		justify-self: start;
 		text-align: left;
 	}
 </style>

--- a/src/lib/components/TimelineItem.svelte
+++ b/src/lib/components/TimelineItem.svelte
@@ -11,26 +11,34 @@
 	setContext<TimelinePosition>('ParentPosition', itemPosition);
 </script>
 
-<li class={`timeline-item ${itemPosition}`} {style}>
-	{#if !$$slots['opposite-content']}
-		<div class="opposite-block" />
-	{:else}
-		<slot name="opposite-content" />
-	{/if}
-	<slot />
-</li>
+<!--<div class={`timeline-item ${itemPosition}`} {style}>-->
+{#if !$$slots['opposite-content']}
+	<div class="timeline-opposite-content" />
+{:else}
+	<slot name="opposite-content" />
+{/if}
+<slot />
+
+<!--</div>-->
 
 <style>
-	:global(.alternate:nth-of-type(even) > .timeline-content) {
+	/*:global(.timeline-content:nth-of-type(even)) {
+		grid-column-start: 1;
 		text-align: right;
 	}
+	:global(.alternate:nth-of-type(odd) > .timeline-content) {
+		grid-column-start: 3;
+	}
 
+	:global(.alternate:nth-of-type(even) > .timeline-opposite-content) {
+		grid-column-start: 1;
+	}
 	:global(.alternate:nth-of-type(odd) > .timeline-opposite-content) {
+		grid-column-start: 3;
 		text-align: right;
-	}
+	}*/
 
-	.opposite-block {
-		flex: 1;
+	.timeline-opposite-content {
 		margin: 6px 16px;
 	}
 
@@ -39,6 +47,7 @@
 		display: flex;
 		position: relative;
 		min-height: 70px;
+		width: max-content;
 	}
 
 	.left {
@@ -50,10 +59,8 @@
 	}
 
 	.alternate:nth-of-type(even) {
-		flex-direction: row-reverse;
 	}
 
 	.alternate:nth-of-type(odd) {
-		flex-direction: row;
 	}
 </style>

--- a/src/lib/components/TimelineItem.svelte
+++ b/src/lib/components/TimelineItem.svelte
@@ -4,63 +4,21 @@
 	import type { TimelinePosition, ParentPosition, TimelineConfig } from '../types';
 
 	export let position: ParentPosition | null = null;
-	export let style: string = null;
 
 	const config = getContext<TimelineConfig>('TimelineConfig');
 	const itemPosition = position ? position : config.rootPosition;
 	setContext<TimelinePosition>('ParentPosition', itemPosition);
 </script>
 
-<!--<div class={`timeline-item ${itemPosition}`} {style}>-->
 {#if !$$slots['opposite-content']}
-	<div class="timeline-opposite-content" />
+	<div class="timeline-opposite-content"></div>
 {:else}
 	<slot name="opposite-content" />
 {/if}
 <slot />
 
-<!--</div>-->
-
 <style>
-	/*:global(.timeline-content:nth-of-type(even)) {
-		grid-column-start: 1;
-		text-align: right;
-	}
-	:global(.alternate:nth-of-type(odd) > .timeline-content) {
-		grid-column-start: 3;
-	}
-
-	:global(.alternate:nth-of-type(even) > .timeline-opposite-content) {
-		grid-column-start: 1;
-	}
-	:global(.alternate:nth-of-type(odd) > .timeline-opposite-content) {
-		grid-column-start: 3;
-		text-align: right;
-	}*/
-
 	.timeline-opposite-content {
 		margin: 6px 16px;
-	}
-
-	.timeline-item {
-		list-style: none;
-		display: flex;
-		position: relative;
-		min-height: 70px;
-		width: max-content;
-	}
-
-	.left {
-		flex-direction: row-reverse;
-	}
-
-	.right {
-		flex-direction: row;
-	}
-
-	.alternate:nth-of-type(even) {
-	}
-
-	.alternate:nth-of-type(odd) {
 	}
 </style>

--- a/src/lib/components/TimelineOppositeContent.svelte
+++ b/src/lib/components/TimelineOppositeContent.svelte
@@ -21,16 +21,33 @@
 <style>
 	.timeline-opposite-content {
 		margin: 0;
-		flex: 1;
 		margin-right: auto;
 		margin: 6px 16px;
+		width: fit-content;
+	}
+
+	.alternate:nth-child(odd of .timeline-opposite-content) {
+		grid-column-start: 3;
+		justify-self: start;
+	}
+	.alternate:nth-child(even of .timeline-opposite-content) {
+		grid-column-start: 1;
+		justify-self: end;
+		text-align: right;
+	}
+
+	.alterate:nth-child(10n + 7) {
+		border: 1px solid red;
 	}
 
 	.left {
+		grid-column-start: 3;
+		justify-self: start;
 		text-align: left;
 	}
 
 	.right {
+		justify-self: end;
 		text-align: right;
 	}
 </style>

--- a/src/lib/components/TimelineSeparator.svelte
+++ b/src/lib/components/TimelineSeparator.svelte
@@ -15,7 +15,7 @@
 	.timeline-separator {
 		display: flex;
 		flex-direction: column;
-		flex: 0;
 		align-items: center;
+		grid-column-start: 2;
 	}
 </style>

--- a/src/lib/types.d.ts
+++ b/src/lib/types.d.ts
@@ -4,6 +4,7 @@ type ParentPosition = 'right' | 'left';
 
 type TimelineConfig = {
 	rootPosition: TimelinePosition;
+	center: boolean;
 };
 
 export { TimelinePosition, ParentPosition, TimelineConfig };

--- a/src/reset.css
+++ b/src/reset.css
@@ -7,7 +7,7 @@
     Remove all the styles of the "User-Agent-Stylesheet", except for the 'display' property
     - The "symbol *" part is to solve Firefox SVG sprite bug
  */
-*:where(:not(iframe, canvas, img, svg, video):not(svg *, symbol *)) {
+*:where(:not(iframe, canvas, img, svg, video):not(svg *, symbol *):not(.no-clear *)) {
 	all: unset;
 	display: revert;
 }

--- a/src/routes/example.svelte
+++ b/src/routes/example.svelte
@@ -69,6 +69,7 @@
 
 <Timeline
 	position="alternate"
+	center="true"
 	style={`
   border-radius: 3%;
   padding: 1rem;
@@ -77,7 +78,7 @@
 	{#each items as item}
 		<TimelineItem>
 			<!-- @migration-task: migrate this slot by hand, `opposite-content` is an invalid identifier -->
-	<TimelineOppositeContent slot="opposite-content">
+			<TimelineOppositeContent slot="opposite-content">
 				<p class="oposite-content-title">{item.year}</p>
 			</TimelineOppositeContent>
 

--- a/src/routes/example.svelte
+++ b/src/routes/example.svelte
@@ -65,34 +65,53 @@
 			color: colors.forth
 		}
 	];
+
+	let centerInput = true;
+	let positionInput = 'alternate';
+	$: console.log('pos:', positionInput);
+	$: console.log('centered:', centerInput);
 </script>
 
-<Timeline
-	position="alternate"
-	center="true"
-	style={`
+<!-- Demo inputs -->
+<form class="example-form no-clear">
+	<label for="center-input">Centered: </label>
+	<input type="checkbox" id="center-input" name="Centered:" bind:checked={centerInput} />
+	<label for="position-input">Position: </label>
+	<select id="position-input" bind:value={positionInput}>
+		<option value="right">Right</option>
+		<option value="left">Left</option>
+		<option value="alternate">Alternate</option>
+	</select>
+</form>
+{#key centerInput + positionInput}
+	<!-- Timeline -->
+	<Timeline
+		position={positionInput}
+		center={centerInput}
+		style={`
   border-radius: 3%;
   padding: 1rem;
   `}
->
-	{#each items as item}
-		<TimelineItem>
-			<!-- @migration-task: migrate this slot by hand, `opposite-content` is an invalid identifier -->
-			<TimelineOppositeContent slot="opposite-content">
-				<p class="oposite-content-title">{item.year}</p>
-			</TimelineOppositeContent>
+	>
+		{#each items as item}
+			<TimelineItem>
+				<!-- @migration-task: migrate this slot by hand, `opposite-content` is an invalid identifier -->
+				<TimelineOppositeContent slot="opposite-content">
+					<p class="oposite-content-title">{item.year}</p>
+				</TimelineOppositeContent>
 
-			<TimelineSeparator>
-				<TimelineDot style={`background-color: ${item.color}; border-color: #fff;`} />
-				<TimelineConnector />
-			</TimelineSeparator>
-			<TimelineContent>
-				<h3 class="content-title">{item.title}</h3>
-				<p class="content-description">{item.description}</p>
-			</TimelineContent>
-		</TimelineItem>
-	{/each}
-</Timeline>
+				<TimelineSeparator>
+					<TimelineDot style={`background-color: ${item.color}; border-color: #fff;`} />
+					<TimelineConnector />
+				</TimelineSeparator>
+				<TimelineContent>
+					<h3 class="content-title">{item.title}</h3>
+					<p class="content-description">{item.description}</p>
+				</TimelineContent>
+			</TimelineItem>
+		{/each}
+	</Timeline>
+{/key}
 
 <style>
 	.oposite-content-title {
@@ -111,5 +130,12 @@
 		color: #d1d3dd;
 		font-weight: lighter;
 		padding: 0.5rem 0;
+	}
+
+	.example-form {
+		color: var(--main-color);
+	}
+	.example-form > label {
+		margin-left: 1rem;
 	}
 </style>


### PR DESCRIPTION
Hey, love this component library, just hoping to contribute a feature that I personally wanted to see here. 

As mentioned in #2, I changed the implementation behind the scenes from an unordered list of flexboxes to a grid layout with three columns (one for opposite content, one for the separator, one for the content). If the timeline is centered, the left and right column widths are each `1fr`, and if not they just fit content. I also updated the example to include some inputs to demonstrate the different positions with and without centering.

I recognize this is kind of a major change 😅 namely `TimelineItem` would no longer be able take a style prop (since it is no longer an html element itself). Documentation would need to be updated to reflect this, also the `center` prop would need to be added to the `Timeline` component docs (which I'm willing to do, just lmk).

I welcome comments, critiques, and requests, thanks

(Fixes #2)